### PR TITLE
fix: filter out deleted test files from affected tests output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+affogato is a GitHub Action that analyzes changed files in pull requests and runs only the affected unit tests. It uses TypeScript project analysis and dependency graph traversal to determine which test files need to run based on the changed source files.
+
+## Core Architecture
+
+### Main Components
+
+- **`src/index.ts`**: GitHub Action entry point that orchestrates the workflow
+- **`src/get-changed-files.ts`**: GitHub API integration to detect changed files in PRs/commits  
+- **`src/get-affected-tests.ts`**: Core dependency analysis engine using ts-morph
+- **`action.yaml`**: GitHub Action configuration and interface definition
+
+### Key Algorithm (get-affected-tests.ts:4-64)
+
+The core logic builds a reverse dependency graph of all TypeScript files in the project:
+1. Parse all source files using ts-morph Project API
+2. Build reverse dependency map from import declarations  
+3. Use BFS traversal starting from changed files to find all affected files
+4. Filter results to only test files matching `*.(test|spec).(ts|tsx)` pattern
+5. Filter out monorepo external paths (starting with `..`)
+
+## Development Commands
+
+```bash
+# Build the action (required for distribution)
+pnpm run build
+
+# Run tests
+pnpm run test
+
+# Type checking
+pnpm run typecheck
+
+# Linting with oxlint
+pnpm run lint
+```
+
+## Package Manager
+
+Uses pnpm (version 10.12.4) with lock file at `pnpm-lock.yaml`.
+
+## Testing Framework
+
+Uses Vitest for testing with configuration in `vitest.config.mts`.
+
+## Key Dependencies
+
+- **ts-morph**: TypeScript compiler API wrapper for AST analysis
+- **@actions/core**: GitHub Action runtime utilities
+- **@actions/github**: GitHub API client for action context
+
+## GitHub Action Interface
+
+**Inputs:**
+- `token` (required): GitHub token for API access
+- `tsconfig` (optional): Path to tsconfig.json, defaults to "./tsconfig.json"
+
+**Outputs:**
+- `affected_tests`: Space-separated list of test file paths to run

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-scope",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Run only the tests affected by your TypeScript changes.",
   "main": "dist/index.js",
   "type": "commonjs",
@@ -15,7 +15,7 @@
   "license": "MIT",
   "packageManager": "pnpm@10.12.4",
   "engines": {
-    "node": ">=22"
+    "node": ">=20"
   },
   "devDependencies": {
     "@types/node": "^24.0.7",

--- a/src/get-affected-tests.test.ts
+++ b/src/get-affected-tests.test.ts
@@ -59,3 +59,21 @@ test("basic case: changing unrelated file returns nothing", () => {
 
   expect(result).toStrictEqual([]);
 });
+
+test("deleted test files are filtered out from affected tests", () => {
+  const project = loadProjectFromCase();
+
+  // Include a non-existent test file in the changed files list
+  const changedFiles = [
+    path.resolve("fixtures/src/foo.ts"),
+    path.resolve("fixtures/src/deleted.test.ts"), // This file doesn't exist
+  ];
+
+  const result = getAffectedTestFiles(changedFiles, project);
+
+  // Should only return existing test files affected by foo.ts
+  expect(result.sort()).toStrictEqual([
+    "fixtures/src/foo.test.ts",
+    "fixtures/src/hoge.test.ts",
+  ]);
+});

--- a/src/get-affected-tests.ts
+++ b/src/get-affected-tests.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import fs from "node:fs";
 import { Project, SourceFile } from "ts-morph";
 
 export function getAffectedTestFiles(
@@ -57,6 +58,7 @@ export function getAffectedTestFiles(
   return (
     Array.from(affected)
       .filter((f) => /\.(test|spec)\.(ts|tsx)$/.test(f))
+      .filter((f) => fs.existsSync(f)) // Filter out deleted files
       .map((absPath) => path.relative(basePath, absPath))
       // If the relative path starts with '..', it might belong to another package in a monorepo environment, so filter it out.
       .filter((f) => !f.startsWith(".."))


### PR DESCRIPTION
## Summary

- Fixed bug where deleted test files were included in `affected_tests` output
- Added `fs.existsSync()` check to filter out non-existent files before returning test file paths
- Added test case to verify deleted files are properly filtered out

## Problem

When test files were deleted in a PR, they would still be included in the `affected_tests` output, causing vitest to fail when trying to run non-existent test files.

## Solution

Added file existence check using `fs.existsSync()` in the filtering pipeline at `get-affected-tests.ts:61` to ensure only existing test files are returned